### PR TITLE
Add sklearn dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ keywords=["modeling", "IDM"]
 dependencies = [
     "emodpy>=2.0",
     "pandas",
+    "scikit-learn",
     "python-calamine",
     "emod-hiv==1.0.4"]
 


### PR DESCRIPTION
Currently, there is a scikit-learn dependency in emod-api.

The only place in emod-api where scikit-learn is used is the `infer_natural_mortality` function, which is deprecated after being moved to emodpy-hiv:
https://github.com/EMOD-Hub/emodpy-hiv/blob/main/emodpy_hiv/demographics/infer_natural_mortality.py

When the scikit-learn dependency is removed from emod-api, it will still be needed in emodpy-hiv.