### PR TITLE
Updates and corrections

### DIFF
--- a/tests/unittests/test_campaign_common.py
+++ b/tests/unittests/test_campaign_common.py
@@ -82,6 +82,8 @@ class TestDemographicsConfig(unittest.TestCase):
 
 @pytest.mark.unit
 class TestRepetitionConfig(unittest.TestCase):
+    EC_name = 'StandardInterventionDistributionEventCoordinator'
+
     def setUp(self):
         with open(manifest.schema_path) as schema_file:
             self.schema_json = json.load(schema_file)
@@ -96,14 +98,14 @@ class TestRepetitionConfig(unittest.TestCase):
 
     def test_set_repetitions(self):
         repetition_config = RepetitionConfig(number_repetitions=3, timesteps_between_repetitions=5)
-        campaign_object = s2c.get_class_with_defaults('StandardEventCoordinator', schema_json=self.schema_json)
+        campaign_object = s2c.get_class_with_defaults(self.EC_name, schema_json=self.schema_json)
         repetition_config._set_repetitions(campaign_object)
         self.assertEqual(campaign_object["Number_Repetitions"], 3)
         self.assertEqual(campaign_object["Timesteps_Between_Repetitions"], 5)
 
     def test_set_repetitions_infinity(self):
         repetition_config = RepetitionConfig(infinite_repetitions=True, timesteps_between_repetitions=30)
-        campaign_object = s2c.get_class_with_defaults('StandardEventCoordinator', schema_json=self.schema_json)
+        campaign_object = s2c.get_class_with_defaults(self.EC_name, schema_json=self.schema_json)
         repetition_config._set_repetitions(campaign_object)
         self.assertEqual(campaign_object["Number_Repetitions"], -1)
         self.assertEqual(campaign_object["Timesteps_Between_Repetitions"], 30)


### PR DESCRIPTION
Planned changes to `emod-api::schema_to_class` include more exceptions:

Use 'StandardInterventionDistributionEventCoordinator' because 'StandardEventCoordinator' isn't a thing.